### PR TITLE
Issue37/building stitch

### DIFF
--- a/building3d/geom/cloud.py
+++ b/building3d/geom/cloud.py
@@ -1,9 +1,11 @@
 import numpy as np
 
 from building3d.geom.vector import normal
+from building3d.geom.vector import is_point_colinear
 from building3d.geom.point import Point
 from building3d.config import GEOM_EPSILON
 from building3d.geom.exceptions import GeometryError
+from building3d.util.roll_back import roll_back
 
 
 def points_to_array(pts: list[Point]) -> np.ndarray:
@@ -59,10 +61,25 @@ def are_points_coplanar(*pts: Point, tol: float = GEOM_EPSILON) -> bool:
     if len(pts) < 3:
         raise GeometryError("Less than 3 points provided to the function")
 
-    if len(pts) == 3:
+    if len(set(pts)) <= 3:
+        # If the number of unique points is less or equal 3, they must be coplanar
         return True
 
-    vec_n = normal(pts[0], pts[1], pts[2])
+    vec_n = np.array([0, 0, 0])
+    num_tries = 0
+    max_tries = len(pts)
+    while np.allclose(vec_n, 0):
+        vec_n = normal(pts[0], pts[1], pts[2])
+        if (np.abs(vec_n) > tol).any():
+            break
+        else:
+            assert is_point_colinear(pts[0], pts[1], pts[2]), \
+                "This case must mean they are colinear. If not, debugging needed."
+            pts = tuple(roll_back(list(pts)))
+        num_tries += 1
+        if num_tries > max_tries:
+            # All points are colinear, so they are also coplanar
+            return True
 
     # Plane equation:
     # ax + by + cz + d = 0

--- a/building3d/geom/cloud.py
+++ b/building3d/geom/cloud.py
@@ -58,9 +58,6 @@ def are_points_in_set(pts: list[Point], are_in: list[Point]) -> bool:
 def are_points_coplanar(*pts: Point, tol: float = GEOM_EPSILON) -> bool:
     """Check if all points lay on the same surface."""
 
-    if len(pts) < 3:
-        raise GeometryError("Less than 3 points provided to the function")
-
     if len(set(pts)) <= 3:
         # If the number of unique points is less or equal 3, they must be coplanar
         return True

--- a/building3d/geom/operations/stitch_solids.py
+++ b/building3d/geom/operations/stitch_solids.py
@@ -164,11 +164,10 @@ def _case_2(sld1: Solid, poly1: Polygon, sld2: Solid, poly2: Polygon) -> tuple[S
     try:
         # If it is 2b, it will raise GeometryError, because the first and last
         # points do not touch any vertex or edges
-        ref_poly = Polygon(slicing_points)
         poly1_int, poly1_ext = poly1.slice(
             slicing_points,
             name1 = f"{poly1.name}-1",
-            pt1 = ref_poly.some_interior_point(),
+            pt1 = poly2.some_interior_point(),
             name2 = f"{poly1.name}-2",
         )
 
@@ -192,7 +191,6 @@ def _case_2(sld1: Solid, poly1: Polygon, sld2: Solid, poly2: Polygon) -> tuple[S
         )
 
         # Make the main slice, needed to stitch poly2 to poly1
-        ref_poly = Polygon(slicing_points)
         # One of the resulting polygons is likely non-convex,
         # so expect triangulation warning messages during the below operation
         num_tries = 0
@@ -202,7 +200,7 @@ def _case_2(sld1: Solid, poly1: Polygon, sld2: Solid, poly2: Polygon) -> tuple[S
                 poly1_int, poly1_ext = poly1_main.slice(
                     slicing_points,
                     name1 = f"{poly1.name}-{poly2.name}",
-                    pt1 = ref_poly.some_interior_point(),
+                    pt1 = poly2.some_interior_point(),
                     name2 = f"{poly1.name}",
                 )
                 break

--- a/building3d/geom/operations/stitch_solids.py
+++ b/building3d/geom/operations/stitch_solids.py
@@ -57,7 +57,7 @@ def stitch_solids(
     elif poly2.area > poly1.area and poly1_points_in_poly2.all():
         case = 3
     else:
-        assert poly1_points_in_poly2.any() or poly2_points_in_poly1.any()
+        assert (poly1_points_in_poly2.any() or poly2_points_in_poly1.any())
         case = 4  # They must be partially overlapping
 
     # Slice the facing polygons

--- a/building3d/geom/polygon.py
+++ b/building3d/geom/polygon.py
@@ -840,8 +840,8 @@ class Polygon:
         are pointing towards each other.
 
         If exact is True, all points of two polygons must be equal (order may be different).
-        If exact is False, the method checks only in points are coplanar and
-        normal vectors are opposite.
+        If exact is False, the method checks only if polygons are overlapping, points are coplanar
+        and normal vectors are opposite.
 
         Args:
             poly: another polygon
@@ -861,10 +861,16 @@ class Polygon:
             this_points = self.points
             other_points = poly.points
             all_points = this_points + other_points
+            # Condition 1: points must be  coplanar
             points_coplanar = are_points_coplanar(*all_points)
+            # Condition 2: normal vectors must be opposite
             normals_opposite = np.isclose(self.normal, poly.normal * -1, rtol=GEOM_RTOL).all()
+            # Condition 3: polygons must be overlapping
+            this_in_other = np.array([self.is_point_inside(p) for p in other_points])
+            other_in_this = np.array([poly.is_point_inside(p) for p in this_points])
+            overlap = this_in_other.any() or other_in_this.any()
 
-            if points_coplanar and normals_opposite:
+            if points_coplanar and normals_opposite and overlap:
                 return True
             else:
                 return False

--- a/building3d/geom/zone.py
+++ b/building3d/geom/zone.py
@@ -44,7 +44,7 @@ class Zone:
         if len(self.solids) > 1:
             adjacent = False
             for _, existing_sld in self.solids.items():
-                if sld.is_adjacent_to_solid(existing_sld):
+                if sld.is_adjacent_to_solid(existing_sld, exact=False):
                     adjacent = True
             if not adjacent:
                 raise GeometryError(

--- a/examples/example_5.py
+++ b/examples/example_5.py
@@ -10,17 +10,31 @@ if __name__ == "__main__":
     solid_3 = box(3, 3, 2, (0, 5, 0), name="solid_3")
     solid_4 = box(3, 3, 2, (1, 1, 3), name="solid_4")
     solid_5 = box(1, 1, 1, (0.5, 0.5, 5), name="solid_5")
-    solid_1, solid_2 = stitch_solids(solid_1, solid_2)
-    solid_1, solid_3 = stitch_solids(solid_1, solid_3)
-    solid_1, solid_4 = stitch_solids(solid_1, solid_4)
-    solid_4, solid_5 = stitch_solids(solid_4, solid_5)
+    solid_6 = box(1, 1, 1, (5, 0, 0), name="solid_6")
+
+    # Below operations are now done automatically in building.stitch_solids()
+    # solid_1, solid_2 = stitch_solids(solid_1, solid_2)
+    # solid_1, solid_3 = stitch_solids(solid_1, solid_3)
+    # solid_1, solid_4 = stitch_solids(solid_1, solid_4)
+    # solid_4, solid_5 = stitch_solids(solid_4, solid_5)
+    # solid_1, solid_6 = stitch_solids(solid_1, solid_6)
+    # solid_2, solid_6 = stitch_solids(solid_2, solid_6)
+
     zone = Zone("zone")
     zone.add_solid(solid_1)
     zone.add_solid(solid_2)
     zone.add_solid(solid_3)
     zone.add_solid(solid_4)
     zone.add_solid(solid_5)
+    zone.add_solid(solid_6)
+
     building = Building(name="building")
     building.add_zone(zone)
 
+    # Plot model before stitching solids
     plot_objects(building)
+
+    # Stitch and plot again
+    building.stitch_solids()
+    plot_objects(building)
+

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -150,6 +150,43 @@ def test_equality():
     assert b4 == b1
 
 
+def test_building_find_adjacent_solids():
+    # Geometry from examples/example_5.py
+    solid_1 = box(5, 5, 3, name="s1")
+    solid_2 = box(3, 3, 2, (5, 1, 0), name="s2")
+    solid_3 = box(3, 3, 2, (0, 5, 0), name="s3")
+    solid_4 = box(3, 3, 2, (1, 1, 3), name="s4")
+    solid_5 = box(1, 1, 1, (0.5, 0.5, 5), name="s5")
+    solid_6 = box(1, 1, 1, (5, 0, 0), name="s6")
+    zone = Zone("z")
+    zone.add_solid(solid_1)
+    zone.add_solid(solid_2)
+    zone.add_solid(solid_3)
+    zone.add_solid(solid_4)
+    zone.add_solid(solid_5)
+    zone.add_solid(solid_6)
+    building = Building(name="building")
+    building.add_zone(zone)
+    adj = building.find_adjacent_solids()
+    assert "z/s2" in adj["z/s1"]
+    assert "z/s1" in adj["z/s2"]
+
+    assert "z/s3" in adj["z/s1"]
+    assert "z/s1" in adj["z/s3"]
+
+    assert "z/s4" in adj["z/s1"]
+    assert "z/s1" in adj["z/s4"]
+
+    assert "z/s5" in adj["z/s4"]
+    assert "z/s4" in adj["z/s5"]
+
+    assert "z/s6" in adj["z/s1"]
+    assert "z/s1" in adj["z/s6"]
+
+    assert "z/s6" in adj["z/s2"]
+    assert "z/s2" in adj["z/s6"]
+
+
 if __name__ == "__main__":
     test_building_mesh_adjacent(show=True)
     test_building_mesh_disjoint(show=True)

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -187,6 +187,34 @@ def test_building_find_adjacent_solids():
     assert "z/s2" in adj["z/s6"]
 
 
+def test_building_stitch_solids():
+    # Geometry from examples/example_5.py
+    solid_1 = box(5, 5, 3, name="s1")
+    original_number_of_polys = len(solid_1.get_polygons())
+
+    solid_2 = box(3, 3, 2, (5, 1, 0), name="s2")
+    solid_3 = box(3, 3, 2, (0, 5, 0), name="s3")
+    solid_4 = box(3, 3, 2, (1, 1, 3), name="s4")
+    solid_5 = box(1, 1, 1, (0.5, 0.5, 5), name="s5")
+    solid_6 = box(1, 1, 1, (5, 0, 0), name="s6")
+    zone = Zone("z")
+    zone.add_solid(solid_1)
+    zone.add_solid(solid_2)
+    zone.add_solid(solid_3)
+    zone.add_solid(solid_4)
+    zone.add_solid(solid_5)
+    zone.add_solid(solid_6)
+    building = Building(name="building")
+    building.add_zone(zone)
+    building.stitch_solids()  # Just testing if there are no errors
+
+    # Testing if solid s1 has more polygons after stitching
+    s1 = building.get_object("z/s1")
+    assert isinstance(s1, Solid)
+    new_number_of_polys = len(s1.get_polygons())
+    assert new_number_of_polys > original_number_of_polys
+
+
 if __name__ == "__main__":
     test_building_mesh_adjacent(show=True)
     test_building_mesh_disjoint(show=True)

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -62,3 +62,11 @@ def test_are_points_coplanar():
         _ = are_points_coplanar(p0)
     assert are_points_coplanar(p0, p1, p2, p4) is False
     assert are_points_coplanar(p0, p1, p2, p3, p4) is False
+
+
+def test_are_points_coplanar_for_colinear_points():
+    p0 = Point(0.0, 0.0, 0.0)
+    p1 = Point(1.0, 0.0, 0.0)
+    p2 = Point(2.0, 0.0, 0.0)
+    p3 = Point(3.0, 0.0, 0.0)
+    assert are_points_coplanar(p0, p1, p2, p3) is True

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -57,9 +57,8 @@ def test_are_points_coplanar():
     assert are_points_coplanar(p0, p1, p2) is True
     assert are_points_coplanar(p0, p1, p3) is True
     assert are_points_coplanar(p1, p2, p3) is True
-    with pytest.raises(GeometryError):
-        _ = are_points_coplanar(p0, p1)
-        _ = are_points_coplanar(p0)
+    assert are_points_coplanar(p0, p1) is True
+    assert are_points_coplanar(p0) is True
     assert are_points_coplanar(p0, p1, p2, p4) is False
     assert are_points_coplanar(p0, p1, p2, p3, p4) is False
 

--- a/tests/test_solid.py
+++ b/tests/test_solid.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from building3d.config import GEOM_EPSILON
+from building3d.geom.predefined.solids.box import box
 from building3d.geom.exceptions import GeometryError
 from building3d.geom.point import Point
 from building3d.geom.polygon import Polygon
@@ -257,6 +258,15 @@ def test_is_adjacent_exact_false():
     assert not sld_2.is_adjacent_to_solid(sld_1, exact=True)
 
 
+def test_is_adjacent_for_coplanar_but_not_touching():
+    # These solids have polygons that are coplanar and with opposite normals
+    # but they are not touching, so they are not adjacent
+    solid_1 = box(3, 3, 2, (1, 1, 3), name="solid_1")
+    solid_2 = box(1, 1, 1, (5, 0, 0), name="solid_2")
+    assert solid_1.is_adjacent_to_solid(solid_2, exact=True) is False
+    assert solid_1.is_adjacent_to_solid(solid_2, exact=False) is False
+
+
 def test_equality():
     p0 = Point(0.0, 0.0, 0.0)
     p1 = Point(1.0, 0.0, 0.0)
@@ -307,3 +317,7 @@ def test_solid_get_mesh():
 
     assert len(verts) == num_verts
     assert len(faces) == num_faces
+
+
+if __name__ == "__main__":
+    test_is_adjacent_exact_false_using_boxes()

--- a/tests/test_solid.py
+++ b/tests/test_solid.py
@@ -317,7 +317,3 @@ def test_solid_get_mesh():
 
     assert len(verts) == num_verts
     assert len(faces) == num_faces
-
-
-if __name__ == "__main__":
-    test_is_adjacent_exact_false_using_boxes()

--- a/tests/test_stitch_solid.py
+++ b/tests/test_stitch_solid.py
@@ -1,6 +1,10 @@
 import numpy as np
 import pytest
 
+from building3d.geom.point import Point
+from building3d.geom.polygon import Polygon
+from building3d.geom.solid import Solid
+from building3d.geom.wall import Wall
 from building3d.geom.exceptions import GeometryError
 from building3d.geom.operations.stitch_solids import stitch_solids
 from building3d.geom.predefined.solids.box import box
@@ -10,6 +14,9 @@ def test_stitch_solids_same_size():
     b1 = box(1, 1, 1, name="b1")
     b2 = box(1, 1, 1, (1, 0, 0), name="b2")
     b1_new, b2_new = stitch_solids(b1, b2)
+
+    assert len(b1.get_polygons()) == len(b2.get_polygons())
+    assert len(b1_new.get_polygons()) == len(b2_new.get_polygons())
 
     assert b1.name == b1_new.name
     assert b1.uid == b1_new.uid
@@ -115,6 +122,9 @@ def test_stitch_solids_overlapping_1():
     b2 = box(1, 1, 1, (1, 0.5, 0.5), name="b2")
     b1_new, b2_new = stitch_solids(b1, b2)
 
+    assert len(b1.get_polygons()) == len(b2.get_polygons())
+    assert len(b1_new.get_polygons()) == len(b2_new.get_polygons())
+
     assert b1.name == b1_new.name
     assert b1.uid == b1_new.uid
     assert np.isclose(b1.volume, b1_new.volume)
@@ -127,7 +137,6 @@ def test_stitch_solids_overlapping_1():
 
 
 def test_stitch_solids_overlapping_2():
-    # TODO: This case does not work, because 1 edge is coincident
     b1 = box(1, 1, 1, name="b1")
     b2 = box(0.5, 0.5, 0.5, (1, 0.5, 0.25), name="b2")
     b1_new, b2_new = stitch_solids(b1, b2)
@@ -144,10 +153,12 @@ def test_stitch_solids_overlapping_2():
 
 
 def test_stitch_solids_overlapping_3():
-    # TODO: This case does not work, because 2 edges are coincident
     b1 = box(1, 1, 1, name="b1")
     b2 = box(1, 1, 1, (1, 0.5, 0.0), name="b2")
     b1_new, b2_new = stitch_solids(b1, b2)
+
+    assert len(b1.get_polygons()) == len(b2.get_polygons())
+    assert len(b1_new.get_polygons()) == len(b2_new.get_polygons())
 
     assert b1.name == b1_new.name
     assert b1.uid == b1_new.uid
@@ -165,6 +176,9 @@ def test_stitch_solids_overlapping_4():
     b2 = box(0.5, 0.5, 0.5, (1, 0.75, 0.25), name="b2")
     b1_new, b2_new = stitch_solids(b1, b2)
 
+    assert len(b1.get_polygons()) == len(b2.get_polygons())
+    assert len(b1_new.get_polygons()) == len(b2_new.get_polygons())
+
     assert b1.name == b1_new.name
     assert b1.uid == b1_new.uid
     assert np.isclose(b1.volume, b1_new.volume)
@@ -180,6 +194,9 @@ def test_stitch_solids_overlapping_4():
     b2 = box(1, 1, 1, name="b2")
     b1_new, b2_new = stitch_solids(b1, b2)
 
+    assert len(b1.get_polygons()) == len(b2.get_polygons())
+    assert len(b1_new.get_polygons()) == len(b2_new.get_polygons())
+
     assert b1.name == b1_new.name
     assert b1.uid == b1_new.uid
     assert np.isclose(b1.volume, b1_new.volume)
@@ -191,5 +208,52 @@ def test_stitch_solids_overlapping_4():
     assert len(b2.get_polygons()) < len(b2_new.get_polygons())
 
 
+def test_stitch_solids_2_corners_additional_points_in_b1():
+    # Create manually a geometry which is equivalent to:
+    # b1 = box(1, 1, 1, name="b1")
+    # However use more points for the polygon adjacent to b2
+    # to check if it still works
+    p0 = Point(0.0, 0.0, 0.0)
+    p1 = Point(1.0, 0.0, 0.0)
+    p1b = Point(1.0, 0.5, 0.0)
+    p2 = Point(1.0, 1.0, 0.0)
+    p3 = Point(0.0, 1.0, 0.0)
+    p4 = Point(0.0, 0.0, 1.0)
+    p5 = Point(1.0, 0.0, 1.0)
+    p6 = Point(1.0, 1.0, 1.0)
+    p7 = Point(0.0, 1.0, 1.0)
+
+    floor = Wall([Polygon([p0, p3, p2, p1b, p1])])  # Additional point must be added here...
+    wall0 = Wall([Polygon([p0, p1, p5, p4])])
+    poly1 = Polygon([p1, p1b, p2, p6, p5])
+    wall1 = Wall([poly1])  # ...and here (Polygon adjacent to b2)
+    wall2 = Wall([Polygon([p3, p7, p6, p2])])
+    wall3 = Wall([Polygon([p0, p4, p7, p3])])
+    ceiling = Wall([Polygon([p4, p5, p6, p7])])
+
+    b1 = Solid([floor, wall0, wall1, wall2, wall3, ceiling], name="b1")
+    b2 = box(1, 1, 0.1, (1, 0, 0), name="b2")
+
+    # Original solids should have the same number of polygons (=6)
+    assert len(b1.get_polygons()) == len(b2.get_polygons())
+    assert len(b1.get_polygons()) == 6
+
+    b1_new, b2_new = stitch_solids(b1, b2)
+
+    # Stitched solids should have different number of polygons
+    # b1 is bigger, so 1 new polygon must be added
+    assert len(b1_new.get_polygons()) == 7
+    assert len(b2_new.get_polygons()) == 6
+
+    assert b1.name == b1_new.name
+    assert b1.uid == b1_new.uid
+    assert np.isclose(b1.volume, b1_new.volume)
+    assert len(b1.get_polygons()) < len(b1_new.get_polygons())
+
+    assert b2.name == b2_new.name
+    assert b2.uid == b2_new.uid
+    assert np.isclose(b2.volume, b2_new.volume)
+
+
 if __name__ == "__main__":
-    test_stitch_solids_diff_sizes_2_corners()
+    test_stitch_solids_2_corners_additional_points_in_b1()

--- a/tests/test_stitch_solid.py
+++ b/tests/test_stitch_solid.py
@@ -60,6 +60,21 @@ def test_stitch_solids_diff_sizes_edge_touching():
     assert np.isclose(b2.volume, b2_new.volume)
 
 
+def test_stitch_solids_diff_sizes_2_corners():
+    b1 = box(1, 1, 1, name="b1")
+    b2 = box(1, 1, 0.1, (1, 0, 0), name="b2")
+    b1_new, b2_new = stitch_solids(b1, b2)
+
+    assert b1.name == b1_new.name
+    assert b1.uid == b1_new.uid
+    assert np.isclose(b1.volume, b1_new.volume)
+    assert len(b1.get_polygons()) < len(b1_new.get_polygons())
+
+    assert b2.name == b2_new.name
+    assert b2.uid == b2_new.uid
+    assert np.isclose(b2.volume, b2_new.volume)
+
+
 def test_stitch_solids_diff_sizes_vertices_touching():
     b1 = box(1, 1, 1, name="b1")
     b2 = box(0.5, 0.5, 0.5, (1, 0, 0), name="b2")
@@ -177,4 +192,4 @@ def test_stitch_solids_overlapping_4():
 
 
 if __name__ == "__main__":
-    test_stitch_solids_overlapping_3()
+    test_stitch_solids_diff_sizes_2_corners()


### PR DESCRIPTION
Fix: https://github.com/krzysztofarendt/building3d/issues/37

`Building.stitch_solids()` automatically finds adjacent solids and cuts their polygons so that they are matching exactly.
However, I decided that `Building.stitch_solids()` should not be called automatically. Manual execution is more explicit.