### PR TITLE
Fix Polygon.distance_point_to_polygon()

### DIFF
--- a/building3d/geom/polygon.py
+++ b/building3d/geom/polygon.py
@@ -666,8 +666,7 @@ class Polygon:
         Note:
             For points not laying inside the orthogonal
             projection, the distance is calculated as the distance
-            to the closest polygon vertex.
-            TODO: Calculate distance to the nearest edge instead.
+            to the closest edge.
         """
         # Translate polygon's to the point p
         _, _, _, d = self.plane_equation_coefficients()
@@ -681,8 +680,13 @@ class Polygon:
         if self.is_point_inside_ortho_projection(p):
             return dist
         else:
-            # Find the closest vertex
-            return self.distance_point_to_polygon_points(p)
+            # Return distance to the closest edge
+            min_dist = np.inf
+            for ed in self.edges:
+                dist = distance_point_to_edge(p, ed[0], ed[1])
+                if dist < min_dist:
+                    min_dist = dist
+            return min_dist
 
     def distance_point_to_polygon_points(self, p: Point) -> float:
         """Return minimum distance between test point and polygon points."""

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -206,6 +206,7 @@ def test_distance_point_to_polygon():
     ptest5 = Point(2.0, 1.0, 1.0)  # distance = np.sqrt(2)
     ptest6 = Point(-1.0, -1.0, 0.0)  # distance = np.sqrt(2)
     ptest7 = Point(0.9, 0.1, 3.0)  # distance = 3
+    ptest8 = Point(0.5, 2.0, 0.0)  # distance = 1 (TODO: must calc. dist. to edge, not to vertex)
 
     poly = Polygon([p0, p1, p2, p3])
 
@@ -223,6 +224,8 @@ def test_distance_point_to_polygon():
     assert np.isclose(d, np.sqrt(2))
     d = poly.distance_point_to_polygon(ptest7)
     assert np.isclose(d, 3)
+    d = poly.distance_point_to_polygon(ptest8)
+    assert np.isclose(d, 1)
 
     p0 = Point(1.0, 1.0, 0.0)
     p1 = Point(0.0, 1.0, 0.0)


### PR DESCRIPTION
Before fix:
- for points not laying inside the orthogonal projection the distance was calculated as the distance to the closest vertex

After fix:
- for points not laying inside the orthogonal projection the distance is calculated as the distance to the closest edge