### PR TITLE
Remove Point comparison operators (__lt__, __gt__, ...)

### DIFF
--- a/building3d/geom/operations/stitch_solids.py
+++ b/building3d/geom/operations/stitch_solids.py
@@ -103,7 +103,10 @@ def find_n_closest_points_between_2_polygons(
             dist_p1_p2[p1].append((d, p2))
 
     for p1 in dist_p1_p2.keys():
-        dist_p1_p2[p1] = sorted(dist_p1_p2[p1])
+        dist_p1_p2[p1] = sorted(
+            dist_p1_p2[p1],
+            key=lambda x: x[0],  # sort by distance (first element of the tuple)
+        )
 
     pairs = []
     points_used = set()

--- a/building3d/geom/point.py
+++ b/building3d/geom/point.py
@@ -26,9 +26,6 @@ class Point:
     def vector(self) -> np.ndarray:
         return np.array([self.x, self.y, self.z])
 
-    def dist_to_origin(self) -> float:
-        return np.sqrt(self.x ** 2 + self.y ** 2 + self.z ** 2)
-
     def add(self, vec: Sequence | np.ndarray):
         if len(vec) != 3:
             raise TypeError("len(vec) must equal to 3")
@@ -104,27 +101,3 @@ class Point:
         y = np.round(self.y, POINT_NUM_DEC)
         z = np.round(self.z, POINT_NUM_DEC)
         return hash((x, y, z))
-
-    def __gt__(self, other):
-        if self.dist_to_origin() > other.dist_to_origin():
-            return True
-        else:
-            return False
-
-    def __lt__(self, other):
-        if self.dist_to_origin() < other.dist_to_origin():
-            return True
-        else:
-            return False
-
-    def __ge__(self, other):
-        if self.dist_to_origin() >= other.dist_to_origin():
-            return True
-        else:
-            return False
-
-    def __le__(self, other):
-        if self.dist_to_origin() <= other.dist_to_origin():
-            return True
-        else:
-            return False


### PR DESCRIPTION
Comparison operators do not make sense for points. They were used only in one line of the code when I was sorting tuples of `(float, Point)`. Using `sorted(..., key=lambda x: x[0])`  removes the need for Point comparison operators.